### PR TITLE
Changes for saving and loading in .h5 models

### DIFF
--- a/nac.py
+++ b/nac.py
@@ -15,7 +15,8 @@ class NAC(Layer):
                  kernel_W_regularizer=None,
                  kernel_M_regularizer=None,
                  kernel_W_constraint=None,
-                 kernel_M_constraint=None):
+                 kernel_M_constraint=None,
+                 **kwargs):
         """
         Neural Accumulator.
 

--- a/nalu.py
+++ b/nalu.py
@@ -20,7 +20,8 @@ class NALU(Layer):
                  kernel_W_constraint=None,
                  kernel_M_constraint=None,
                  gate_constraint=None,
-                 epsilon=1e-7):
+                 epsilon=1e-7,
+                 **kwargs):
         """
         Neural Arithmatic and Logical Unit.
 


### PR DESCRIPTION
Added **kwargs in __init__() to NAC and NALU to allow for saving and loading of the models as Keras .h5 models